### PR TITLE
Ported /dev/fd/X magic mount point enabling --fusemount in apptainer (juicefs#5014)

### DIFF
--- a/fuse/mount_linux.go
+++ b/fuse/mount_linux.go
@@ -118,6 +118,14 @@ func mount(mountPoint string, opts *MountOptions, ready chan<- error) (fd int, e
 		}
 	}
 
+	fd = parseFuseFd(mountPoint)
+	if fd >= 0 {
+		if opts.Debug {
+			log.Printf("mount: magic mountpoint %q, using fd %d", mountPoint, fd)
+		}
+    return fd, nil
+	} 
+
 	local, remote, err := unixgramSocketpair()
 	if err != nil {
 		return

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"path"
+	"strconv"
 	"runtime"
 	"sort"
 	"strings"
@@ -1124,4 +1126,18 @@ func (ms *Server) WaitMount() error {
 		return err
 	}
 	return pollHack(ms.mountPoint)
+}
+
+// parseFuseFd checks if `mountPoint` is the special form /dev/fd/N (with N >= 0),
+// and returns N in this case. Returns -1 otherwise.
+func parseFuseFd(mountPoint string) (fd int) {
+	dir, file := path.Split(mountPoint)
+	if dir != "/dev/fd/" {
+		return -1
+	}
+	fd, err := strconv.Atoi(file)
+	if err != nil || fd <= 0 {
+		return -1
+	}
+	return fd
 }


### PR DESCRIPTION
See https://github.com/juicedata/juicefs/issues/5014

**Note:** `juicefs` fails checking the mount point in function `checkMountpoint` with fatal error "The mount point is not ready in %d seconds, exit it", even if the mount is correct. It would be nice to have an option to skip the `checkMountpoint`.
