### PR TITLE
splice: refactor pipe pool

### DIFF
--- a/splice/copy.go
+++ b/splice/copy.go
@@ -54,11 +54,11 @@ func CopyFile(dstName string, srcName string, mode int) error {
 }
 
 func CopyFds(dst *os.File, src *os.File) (err error) {
-	p, err := splicePool.get()
+	p, err := Get()
 	if p != nil {
 		p.Grow(256 * 1024)
 		_, err := SpliceCopy(dst, src, p)
-		splicePool.done(p)
+		Done(p)
 		return err
 	} else {
 		_, err = io.Copy(dst, src)

--- a/splice/copy_test.go
+++ b/splice/copy_test.go
@@ -56,15 +56,13 @@ func TestSpliceCopy(t *testing.T) {
 	if maxPipeSize%4096 != 0 || maxPipeSize < 4096 {
 		t.Error("pipe size should be page size multiple", maxPipeSize)
 	}
-	pool := newSplicePairPool()
-	p, err := pool.get()
+	p, err := Get()
 	if p != nil {
 		p.MaxGrow()
 		t.Logf("Splice size %d", p.size)
 		SpliceCopy(dst, src, p)
 		dst.Close()
 		src.Close()
-		p.Close()
 	} else {
 		t.Error("Could not open splice: ", err)
 	}

--- a/splice/pair.go
+++ b/splice/pair.go
@@ -11,6 +11,10 @@ import (
 type Pair struct {
 	r, w int
 	size int
+
+	// We want to use a finalizer, so ensure that the size is
+	// large enough to not use the tiny allocator.
+	_ [12]byte
 }
 
 func (p *Pair) MaxGrow() {

--- a/splice/pair_darwin.go
+++ b/splice/pair_darwin.go
@@ -20,7 +20,7 @@ func (p *Pair) discard() {
 	panic("not implemented")
 }
 
-func (p *Pair) Close() error {
+func (p *Pair) close() error {
 	panic("not implemented")
 }
 

--- a/splice/pair_linux.go
+++ b/splice/pair_linux.go
@@ -54,7 +54,7 @@ func (p *Pair) discard() {
 	}
 }
 
-func (p *Pair) Close() error {
+func (p *Pair) close() error {
 	err1 := syscall.Close(p.r)
 	err2 := syscall.Close(p.w)
 	if err1 != nil {

--- a/splice/pair_windows.go
+++ b/splice/pair_windows.go
@@ -20,7 +20,7 @@ func (p *Pair) discard() {
 	panic("not implemented")
 }
 
-func (p *Pair) Close() error {
+func (p *Pair) close() error {
 	panic("not implemented")
 }
 

--- a/splice/pool.go
+++ b/splice/pool.go
@@ -5,10 +5,25 @@
 package splice
 
 import (
+	"fmt"
+	"runtime"
 	"sync"
 )
 
-var splicePool *pairPool
+var splicePool = sync.Pool{
+	New: newPoolPipe,
+}
+
+func newPoolPipe() interface{} {
+	// Discard the error which occurred during the creation of pipe buffer,
+	// redirecting the data transmission to the conventional way utilizing read() + write() as a fallback.
+	p := newPipe()
+	if p == nil {
+		return nil
+	}
+	runtime.SetFinalizer(p, destroyPipe)
+	return p
+}
 
 type pairPool struct {
 	sync.Mutex
@@ -16,90 +31,22 @@ type pairPool struct {
 	usedCount int
 }
 
-func ClearSplicePool() {
-	splicePool.clear()
-}
-
 func Get() (*Pair, error) {
-	return splicePool.get()
-}
-
-func Total() int {
-	return splicePool.total()
-}
-
-func Used() int {
-	return splicePool.used()
+	p := splicePool.Get()
+	if p == nil {
+		return nil, fmt.Errorf("create pipe failed")
+	}
+	return p.(*Pair), nil
 }
 
 // Done returns the pipe pair to pool.
 func Done(p *Pair) {
-	splicePool.done(p)
+	p.discard()
+	splicePool.Put(p)
 }
 
 // Closes and discards pipe pair.
 func Drop(p *Pair) {
-	splicePool.drop(p)
-}
-
-func newSplicePairPool() *pairPool {
-	return &pairPool{}
-}
-
-func (pp *pairPool) clear() {
-	pp.Lock()
-	for _, p := range pp.unused {
-		p.Close()
-	}
-	pp.unused = pp.unused[:0]
-	pp.Unlock()
-}
-
-func (pp *pairPool) used() (n int) {
-	pp.Lock()
-	n = pp.usedCount
-	pp.Unlock()
-
-	return n
-}
-
-func (pp *pairPool) total() int {
-	pp.Lock()
-	n := pp.usedCount + len(pp.unused)
-	pp.Unlock()
-	return n
-}
-
-func (pp *pairPool) drop(p *Pair) {
-	p.Close()
-	pp.Lock()
-	pp.usedCount--
-	pp.Unlock()
-}
-
-func (pp *pairPool) get() (p *Pair, err error) {
-	pp.Lock()
-	defer pp.Unlock()
-
-	pp.usedCount++
-	l := len(pp.unused)
-	if l > 0 {
-		p := pp.unused[l-1]
-		pp.unused = pp.unused[:l-1]
-		return p, nil
-	}
-
-	return newSplicePair()
-}
-
-func (pp *pairPool) done(p *Pair) {
-	p.discard()
-	pp.Lock()
-	pp.usedCount--
-	pp.unused = append(pp.unused, p)
-	pp.Unlock()
-}
-
-func init() {
-	splicePool = newSplicePairPool()
+	runtime.SetFinalizer(p, nil)
+	destroyPipe(p)
 }

--- a/splice/splice.go
+++ b/splice/splice.go
@@ -66,22 +66,3 @@ func init() {
 
 const F_SETPIPE_SZ = 1031
 const F_GETPIPE_SZ = 1032
-
-func newSplicePair() (p *Pair, err error) {
-	p = &Pair{}
-	p.r, p.w, err = osPipe()
-	if err != nil {
-		return nil, err
-	}
-	var errNo syscall.Errno
-	p.size, errNo = fcntl(uintptr(p.r), F_GETPIPE_SZ, 0)
-	if errNo == syscall.EINVAL {
-		p.size = DefaultPipeSize
-		return p, nil
-	}
-	if errNo != 0 {
-		p.Close()
-		return nil, fmt.Errorf("fcntl getsize: %v", errNo)
-	}
-	return p, nil
-}

--- a/splice/splice_darwin.go
+++ b/splice/splice_darwin.go
@@ -1,9 +1,16 @@
 package splice
 
 import (
-	"fmt"
 	"syscall"
 )
+
+func newPipe() *Pair {
+	return nil
+}
+
+func destroyPipe(p *Pair) {
+	panic("not implemented")
+}
 
 // copy & paste from syscall.
 func fcntl(fd uintptr, cmd int, arg int) (val int, errno syscall.Errno) {
@@ -11,8 +18,4 @@ func fcntl(fd uintptr, cmd int, arg int) (val int, errno syscall.Errno) {
 	val = int(r0)
 	errno = syscall.Errno(e1)
 	return
-}
-
-func osPipe() (int, int, error) {
-	return 0, 0, fmt.Errorf("not implemented")
 }

--- a/splice/splice_linux.go
+++ b/splice/splice_linux.go
@@ -1,6 +1,9 @@
 package splice
 
-import "syscall"
+import (
+	"log"
+	"syscall"
+)
 
 // copy & paste from syscall.
 func fcntl(fd uintptr, cmd int, arg int) (val int, errno syscall.Errno) {
@@ -10,8 +13,21 @@ func fcntl(fd uintptr, cmd int, arg int) (val int, errno syscall.Errno) {
 	return
 }
 
-func osPipe() (int, int, error) {
+func newPipe() *Pair {
 	var fds [2]int
-	err := syscall.Pipe2(fds[:], syscall.O_NONBLOCK)
-	return fds[0], fds[1], err
+	var err error
+	err = syscall.Pipe2(fds[:], syscall.O_CLOEXEC|syscall.O_NONBLOCK)
+	if err != nil {
+		log.Printf("Warning: create pipe failed: %v\n", err)
+		return nil
+	}
+	fcntl(uintptr(fds[0]), syscall.F_SETPIPE_SZ, maxPipeSize)
+	return &Pair{r: fds[0], w: fds[1], size: maxPipeSize}
+}
+
+func destroyPipe(p *Pair) {
+	err := p.close()
+	if err != nil {
+		log.Printf("close pipe failed: %v\n", err)
+	}
 }

--- a/splice/splice_linux.go
+++ b/splice/splice_linux.go
@@ -21,7 +21,15 @@ func newPipe() *Pair {
 		log.Printf("Warning: create pipe failed: %v\n", err)
 		return nil
 	}
-	fcntl(uintptr(fds[0]), syscall.F_SETPIPE_SZ, maxPipeSize)
+	if resizable {
+		_, ferr := fcntl(uintptr(fds[0]), syscall.F_SETPIPE_SZ, maxPipeSize)
+		if ferr != syscall.Errno(0) {
+			syscall.Close(fds[0])
+			syscall.Close(fds[1])
+			log.Printf("Warning: grow pipe failed: %v\n", ferr)
+			return nil
+		}
+	}
 	return &Pair{r: fds[0], w: fds[1], size: maxPipeSize}
 }
 

--- a/splice/splice_windows.go
+++ b/splice/splice_windows.go
@@ -1,12 +1,15 @@
 package splice
 
 import (
-	"fmt"
 	"syscall"
 )
 
-func osPipe() (int, int, error) {
-	return 0, 0, fmt.Errorf("not implemented")
+func newPipe() *Pair {
+	return nil
+}
+
+func destroyPipe(p *Pair) {
+	panic("not implemented")
 }
 
 func fcntl(fd uintptr, cmd int, arg int) (val int, errno syscall.Errno) {


### PR DESCRIPTION
Sadly we could not use go's internal package, most of the refactor is from linux_splice.go inside go's internal package. Also removed unused APIs, we respect most of the APIs.