### PR TITLE
fix: avoid interrupting requests during graceful shutdown

### DIFF
--- a/fuse/server.go
+++ b/fuse/server.go
@@ -525,7 +525,6 @@ func (ms *Server) checkLostRequests() {
 		for u > last+1 {
 			last++
 			// interrupt lost one
-			log.Printf("FUSE: interrupt lost one %d", last)
 			ms.returnInterrupted(last)
 		}
 	}
@@ -540,7 +539,6 @@ func (ms *Server) checkLostRequests() {
 	}
 	var c int
 	for last > 0 && c < 6e6 {
-		log.Printf("FUSE: interrupt historic ones %d", last)
 		ms.returnInterrupted(last)
 		last--
 		c++

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -475,7 +475,6 @@ func (ms *Server) getRootInode() (int, error) {
 }
 
 func (ms *Server) checkLostRequests() {
-	log.Printf("FUSE: start checking lost requests")
 	go func() {
 		// issue a few requests to interrupt lost ones
 		for i := 0; i < 30; i++ {
@@ -485,8 +484,6 @@ func (ms *Server) checkLostRequests() {
 	}()
 	start := time.Now()
 	var recentUnique []uint64
-	var maxUnique uint64
-	var inflight int
 	time.Sleep(time.Second * 3)
 	for {
 		ms.reqMu.Lock()
@@ -497,8 +494,6 @@ func (ms *Server) checkLostRequests() {
 		used := time.Since(start)
 		if len(ms.recentUnique) >= 30 || len(ms.recentUnique) > 1 && used > time.Second*10 {
 			recentUnique = ms.recentUnique
-			maxUnique = ms.maxUnique
-			inflight = len(ms.reqInflight)
 			ms.recentUnique = nil
 			ms.reqMu.Unlock()
 			break
@@ -515,12 +510,8 @@ func (ms *Server) checkLostRequests() {
 	}
 
 	sort.Slice(recentUnique, func(i, j int) bool { return recentUnique[i] < recentUnique[j] })
-	log.Printf("FUSE: checking lost requests with %d samples after %s: samples=%v maxUnique=%d inflight=%d", len(recentUnique), time.Since(start), recentUnique, maxUnique, inflight)
 	var last = recentUnique[0]
 	for _, u := range recentUnique[:len(recentUnique)/2] {
-		if u > last+1 {
-			log.Printf("FUSE: checking lost requests gap: u=%d last=%d", last, u)
-		}
 		for u > last+1 {
 			last++
 			// interrupt lost one
@@ -530,13 +521,6 @@ func (ms *Server) checkLostRequests() {
 	}
 	// interrupt historic ones
 	last = recentUnique[0] - 1
-	if last > 0 {
-		first := uint64(1)
-		if last >= 6e6 {
-			first = last - 6e6 + 1
-		}
-		log.Printf("FUSE: checking historic requests: first=%d last=%d", first, last)
-	}
 	var c int
 	for last > 0 && c < 6e6 {
 		ms.returnInterrupted(last)

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -282,7 +282,7 @@ func (ms *Server) mount(opt *MountOptions) error {
 			ms.fileSystem.Init(ms)
 			ms.recentUnique = make([]uint64, 0)
 			go ms.sendFd(path)
-			go ms.checkLostRequests()
+			// go ms.checkLostRequests()
 			return nil
 		}
 	}

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -282,7 +282,7 @@ func (ms *Server) mount(opt *MountOptions) error {
 			ms.fileSystem.Init(ms)
 			ms.recentUnique = make([]uint64, 0)
 			go ms.sendFd(path)
-			// go ms.checkLostRequests()
+			go ms.checkLostRequests()
 			return nil
 		}
 	}
@@ -475,6 +475,7 @@ func (ms *Server) getRootInode() (int, error) {
 }
 
 func (ms *Server) checkLostRequests() {
+	log.Printf("FUSE: start checking lost requests")
 	go func() {
 		// issue a few requests to interrupt lost ones
 		for i := 0; i < 30; i++ {
@@ -484,6 +485,8 @@ func (ms *Server) checkLostRequests() {
 	}()
 	start := time.Now()
 	var recentUnique []uint64
+	var maxUnique uint64
+	var inflight int
 	time.Sleep(time.Second * 3)
 	for {
 		ms.reqMu.Lock()
@@ -494,6 +497,8 @@ func (ms *Server) checkLostRequests() {
 		used := time.Since(start)
 		if len(ms.recentUnique) >= 30 || len(ms.recentUnique) > 1 && used > time.Second*10 {
 			recentUnique = ms.recentUnique
+			maxUnique = ms.maxUnique
+			inflight = len(ms.reqInflight)
 			ms.recentUnique = nil
 			ms.reqMu.Unlock()
 			break
@@ -510,18 +515,32 @@ func (ms *Server) checkLostRequests() {
 	}
 
 	sort.Slice(recentUnique, func(i, j int) bool { return recentUnique[i] < recentUnique[j] })
+	log.Printf("FUSE: checking lost requests with %d samples after %s: min=%d median=%d max=%d maxUnique=%d inflight=%d",
+		len(recentUnique), time.Since(start), recentUnique[0], recentUnique[len(recentUnique)/2], recentUnique[len(recentUnique)-1], maxUnique, inflight)
 	var last = recentUnique[0]
 	for _, u := range recentUnique[:len(recentUnique)/2] {
+		if u > last+1 {
+			log.Printf("FUSE: checking lost requests gap: first=%d last=%d", last+1, u-1)
+		}
 		for u > last+1 {
 			last++
 			// interrupt lost one
+			log.Printf("FUSE: interrupt lost one %d", last)
 			ms.returnInterrupted(last)
 		}
 	}
 	// interrupt historic ones
 	last = recentUnique[0] - 1
+	if last > 0 {
+		first := uint64(1)
+		if last >= 6e6 {
+			first = last - 6e6 + 1
+		}
+		log.Printf("FUSE: checking historic requests: first=%d last=%d", first, last)
+	}
 	var c int
 	for last > 0 && c < 6e6 {
+		log.Printf("FUSE: interrupt historic ones %d", last)
 		ms.returnInterrupted(last)
 		last--
 		c++

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -716,19 +716,6 @@ func (ms *Server) Shutdown() bool {
 				ms.reqMu.Unlock()
 			}
 		}
-		if time.Since(start) > time.Second*3 {
-			ms.reqMu.Lock()
-			if len(ms.reqInflight) > 0 {
-				log.Printf("interrupt %d inflight requests", len(ms.reqInflight))
-			}
-			for _, req := range ms.reqInflight {
-				if !req.interrupted {
-					close(req.cancel)
-					req.interrupted = true
-				}
-			}
-			ms.reqMu.Unlock()
-		}
 		if time.Since(start) > time.Second*10 {
 			log.Printf("FUSE session is still busy (%d readers, %d requests, %d writers) after 10 seconds, give up",
 				readers, reqs, atomic.LoadInt64(&ms.writes))
@@ -744,13 +731,13 @@ func (ms *Server) Shutdown() bool {
 		ms.reqMu.Unlock()
 	}
 
-	// double check
+	// Do not transfer a session with requests still in flight.
 	ms.reqMu.Lock()
 	if len(ms.reqInflight) > 0 {
-		log.Printf("there are %d requests in flight, interrupt them", len(ms.reqInflight))
-		for _, req := range ms.reqInflight {
-			ms.returnInterrupted(req.inHeader.Unique)
-		}
+		log.Printf("there are %d requests in flight, give up", len(ms.reqInflight))
+		ms.shutdown = false
+		ms.reqMu.Unlock()
+		return false
 	}
 	ms.reqMu.Unlock()
 	return true

--- a/fuse/server.go
+++ b/fuse/server.go
@@ -515,18 +515,18 @@ func (ms *Server) checkLostRequests() {
 	}
 
 	sort.Slice(recentUnique, func(i, j int) bool { return recentUnique[i] < recentUnique[j] })
-	log.Printf("FUSE: checking lost requests with %d samples after %s: min=%d median=%d max=%d maxUnique=%d inflight=%d",
-		len(recentUnique), time.Since(start), recentUnique[0], recentUnique[len(recentUnique)/2], recentUnique[len(recentUnique)-1], maxUnique, inflight)
+	log.Printf("FUSE: checking lost requests with %d samples after %s: samples=%v maxUnique=%d inflight=%d", len(recentUnique), time.Since(start), recentUnique, maxUnique, inflight)
 	var last = recentUnique[0]
 	for _, u := range recentUnique[:len(recentUnique)/2] {
 		if u > last+1 {
-			log.Printf("FUSE: checking lost requests gap: first=%d last=%d", last+1, u-1)
+			log.Printf("FUSE: checking lost requests gap: u=%d last=%d", last, u)
 		}
 		for u > last+1 {
 			last++
 			// interrupt lost one
 			ms.returnInterrupted(last)
 		}
+		last = u
 	}
 	// interrupt historic ones
 	last = recentUnique[0] - 1


### PR DESCRIPTION
During a smooth upgrade, active read requests could receive `EINTR`, causing applications such as Vdbench to abort.

vdbench logged:

```text
03:53:57.644 localhost-0: 03:53:57.644 03:53:57.642 op: read   lun: /data2/vdb.1_2.dir/vdb_f0009.file lba:     51838976 0x03170000 xfer:    65536 errno: EINTR: 'Interrupted system call'
03:53:58.145
03:53:58.145 'data_errors=1' requested. Abort rd=rd1 after last error.
03:53:58.145
java.lang.RuntimeException: 'data_errors=1' requested. Abort rd=rd1 after last error.
	at Vdb.common.failure(common.java:335)
	at Vdb.common.failure(common.java:284)
	at Vdb.ErrorLog.countErrorsOnMaster(ErrorLog.java:213)
	at Vdb.SlaveOnMaster.processSlave(SlaveOnMaster.java:204)
	at Vdb.SlaveOnMaster.run(SlaveOnMaster.java:42)
---
```

mount process log
```
FUSE: interrupt request 23630
writer: Write/Writev failed, err: ENOENT. opcode: READ
```

There were two paths that could interrupt live requests:

1. Shutdown() canceled in-flight requests after waiting for 3 seconds, then continued the restart. This made a supposedly graceful restart visible to applications as EINTR.

2. checkLostRequests() did not advance last after processing a sampled unique. A unique already observed by the new process could therefore be scanned again and incorrectly completed with EINTR.